### PR TITLE
Dynamically spin up cores

### DIFF
--- a/0setup.jl
+++ b/0setup.jl
@@ -1,6 +1,6 @@
 # from a suggestion at https://discourse.julialang.org/t/install-a-packages-from-a-list/30920/3
 
-using Pkg
+using Pkg, Distributed
 
 dependencies = [
     "JLD", 
@@ -14,4 +14,9 @@ dependencies = [
 ]
 
 Pkg.add(dependencies)
+
+# add other workers
+if nprocs() == 1
+  addprocs(length(Sys.cpu_info()) ÷ 2 - 1)
+end
 

--- a/0setup.jl
+++ b/0setup.jl
@@ -15,7 +15,7 @@ dependencies = [
 
 Pkg.add(dependencies)
 
-# add other workers
+# dynamically start up cores if not done by command line
 if nprocs() == 1
   addprocs(length(Sys.cpu_info()) ÷ 2 - 1)
 end

--- a/README.md
+++ b/README.md
@@ -66,8 +66,5 @@ To run code directly, use
 ```shell
 docker run -it -v $(pwd):/code \
      -w /code \
-     $MYHUBID/${MYIMG}:$TAG julia -O3 -p 20 mainmulti.jl
+     $MYHUBID/${MYIMG}:$TAG julia mainmulti.jl
 ```
-
-Note that `-p 20`  will use 20 cores, as the Docker image has access to all of the cores of the host system unless specifically limited.
-


### PR DESCRIPTION
Added the code to `setup.jl`, I also removed the `O3` option which defaults to SIMD. In practice I don't think SIMD ever causes issues but seems safer to keep it off as default.